### PR TITLE
[Perf Opt] Change tile policy when reduce number > 2048

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -191,9 +191,9 @@ std::shared_ptr<cinn::ir::GroupTileInfo> OpLowererImpl::GetGroupTileInfo(
     reduce_inner_num = 8;
   } else if (reduce_numel > 2048) {
     spatial_block = 1;
-    reduce_block = 2048;
-    warp_num = 8;
-    reduce_inner_num = int64_t(std::ceil(reduce_numel * 1.0 / 256.0));
+    reduce_block = int64_t(std::ceil(reduce_numel * 1.0 / 1024.0)) * 1024;
+    warp_num = 32;
+    reduce_inner_num = int64_t(std::ceil(reduce_numel * 1.0 / 1024.0));
     spatial_inner_num = 1;
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
[Perf Opt] Change tile policy when reduce number > 2048

When `shape = [1, 1, 4096]`, phi = 7.68 us, CINN = 21.503 us, CINN_opt = 9.696 us

